### PR TITLE
GUACAMOLE-1633: Add support of alternate screen buffer

### DIFF
--- a/src/terminal/terminal-handlers.c
+++ b/src/terminal/terminal-handlers.c
@@ -885,6 +885,10 @@ int guac_terminal_csi(guac_terminal* term, unsigned char c) {
                 if (flag != NULL)
                     *flag = true;
 
+                /* Open alternate screen buffer */
+                if (argv[0] == 1049)
+                    guac_terminal_switch_buffers(term, true);
+
                 break;
 
             /* l: Reset Mode */
@@ -894,6 +898,10 @@ int guac_terminal_csi(guac_terminal* term, unsigned char c) {
                 flag = __guac_terminal_get_flag(term, argv[0], private_mode_character);
                 if (flag != NULL)
                     *flag = false;
+                
+                /* Close alternate screen buffer */
+                if (argv[0] == 1049)
+                    guac_terminal_switch_buffers(term, false);
 
                 break;
 

--- a/src/terminal/terminal.c
+++ b/src/terminal/terminal.c
@@ -482,9 +482,12 @@ guac_terminal* guac_terminal_create(guac_client* client,
     if (initial_scrollback < GUAC_TERMINAL_MAX_ROWS)
         initial_scrollback = GUAC_TERMINAL_MAX_ROWS;
 
-    /* Init buffer */
+    /* Init current and alternate buffer */
     term->buffer = guac_terminal_buffer_alloc(initial_scrollback,
             &default_char);
+    term->buffer_alt = guac_terminal_buffer_alloc(initial_scrollback,
+            &default_char);
+    term->buffer_switched = false;
 
     /* Init display */
     term->display = guac_terminal_display_alloc(client,
@@ -633,8 +636,9 @@ void guac_terminal_free(guac_terminal* term) {
     /* Free display */
     guac_terminal_display_free(term->display);
 
-    /* Free buffer */
+    /* Free buffers */
     guac_terminal_buffer_free(term->buffer);
+    guac_terminal_buffer_free(term->buffer_alt);
 
     /* Free scrollbar */
     guac_terminal_scrollbar_free(term->scrollbar);
@@ -2383,4 +2387,60 @@ void guac_terminal_remove_user(guac_terminal* terminal, guac_user* user) {
 
     /* Remove the user from the terminal cursor */
     guac_common_cursor_remove_user(terminal->cursor, user);
+}
+
+void guac_terminal_switch_buffers(guac_terminal* terminal, bool to_alt) {
+
+    /* Already on requested buffer */
+    if (terminal->buffer_switched == to_alt)
+        return;
+
+    /* Keep new buffer state */
+    terminal->buffer_switched = to_alt;
+
+    /* Inversion of buffers pointers to switch to alternate */
+    guac_terminal_buffer* temp_buffer = terminal->buffer;
+    terminal->buffer = terminal->buffer_alt;
+    terminal->buffer_alt = temp_buffer;
+
+    /* Switch to alternate buffer */
+    if (to_alt) {
+
+        /* Backup cursor position before switching alternate buffer */
+        terminal->visible_cursor_col_alt = terminal->visible_cursor_col;
+        terminal->visible_cursor_row_alt = terminal->visible_cursor_row;
+        terminal->cursor_col_alt = terminal->cursor_col;
+        terminal->cursor_row_alt = terminal->cursor_row;
+
+        /* Clean old alternate buffer content and selection */
+        guac_terminal_reset(terminal);
+
+    }
+
+    /* Switch to normal buffer */
+    else {
+
+        /* Restore cursor position before switching normal buffer */
+        terminal->visible_cursor_col = terminal->visible_cursor_col_alt;
+        terminal->visible_cursor_row = terminal->visible_cursor_row_alt;
+        terminal->cursor_col = terminal->cursor_col_alt;
+        terminal->cursor_row = terminal->cursor_row_alt;
+
+        /* Repaint and resize overall display */
+        guac_terminal_repaint_default_layer(terminal, terminal->client->socket);
+        __guac_terminal_redraw_rect(terminal, 0, 0,
+                terminal->term_height - 1,
+                terminal->term_width - 1);
+
+        /* Restore scrollbar state */
+        guac_terminal_scrollbar_set_bounds(terminal->scrollbar,
+                -guac_terminal_get_available_scroll(terminal), 0);
+
+        /* Clear selection */
+        terminal->text_selected = false;
+        terminal->selection_committed = false;
+        guac_terminal_notify(terminal);
+
+    }
+
 }

--- a/src/terminal/terminal/terminal-priv.h
+++ b/src/terminal/terminal/terminal-priv.h
@@ -270,6 +270,11 @@ struct guac_terminal {
     int visible_cursor_col;
 
     /**
+     * Backup of cursor position when using alternate buffer.
+     */
+    int cursor_row_alt, cursor_col_alt, visible_cursor_row_alt, visible_cursor_col_alt;
+
+    /**
      * The row of the saved cursor (ESC 7).
      */
     int saved_cursor_row;
@@ -310,6 +315,18 @@ struct guac_terminal {
      * facilitates transfer of a set of changes to the remote display.
      */
     guac_terminal_buffer* buffer;
+
+    /**
+     * Alternate buffer.
+     */
+    guac_terminal_buffer* buffer_alt;
+
+    /**
+     * Actual state of the buffer:
+     *  - true if switched to alternate buffer.
+     *  - false if normal buffer.
+     */
+    bool buffer_switched;
 
     /**
      * Automatically place a tabstop every N characters. If zero, then no
@@ -665,6 +682,19 @@ void guac_terminal_copy_rows(guac_terminal* terminal,
  * Flushes all pending operations within the given guac_terminal.
  */
 void guac_terminal_flush(guac_terminal* terminal);
+
+/**
+ * Swith betwen normal and alternate buffer.
+ *
+ * @param terminal
+ *      Terminal on which we switch buffers.
+ *
+ * @param to_alt
+ *      Direction of buffer inversion.
+ *      True if normal to alternate buffer.
+ *      False if alternate to normal buffer.
+ */
+void guac_terminal_switch_buffers(guac_terminal* terminal, bool to_alt);
 
 #endif
 


### PR DESCRIPTION
Add support of alternate screen buffer for tools like less/vi/man/...

Before:
![image](https://github.com/corentin-soriano/guacamole-server/assets/107032768/18dc1af1-424e-410e-8782-18f61edb7d97)

After:
![image](https://github.com/corentin-soriano/guacamole-server/assets/107032768/c7453113-2f03-4ec8-bf27-4481fd67d0f9)
![image](https://github.com/corentin-soriano/guacamole-server/assets/107032768/e23d5b26-441d-42fb-8c4d-02795f4e4760)
![image](https://github.com/corentin-soriano/guacamole-server/assets/107032768/87c9a3e1-23a5-46e7-b83f-cb1964608c30)
